### PR TITLE
Add motion module

### DIFF
--- a/nodes/Node_v13/Motion.cpp
+++ b/nodes/Node_v13/Motion.cpp
@@ -1,0 +1,34 @@
+#include "Motion.h"
+
+void Motion::begin() {
+  Serial << "Motion::begin()" << endl;
+
+  pinMode(PIN_PIR, INPUT);
+  this->triggerTimeout = Metro(this->triggerTimeoutMillis);
+}
+
+bool Motion::update() {
+  bool newMotionDetectedState;
+  if (digitalRead(PIN_PIR) == HIGH) {
+    this->triggerTimeout.reset();
+    newMotionDetectedState = true;
+  } else if (this->triggerTimeout.check()) {
+    newMotionDetectedState = false;
+  }
+
+  bool motionChanged = newMotionDetectedState != this->motionDetected;
+  if (motionChanged) {
+    this->motionDetected = newMotionDetectedState;
+  }
+  return motionChanged;
+}
+
+void Motion::setTriggerTimeout(unsigned long ms) {
+  this->triggerTimeoutMillis = ms;
+  this->triggerTimeout.interval(this->triggerTimeoutMillis);
+  Serial << "Motion::setTriggerTimeout " << this->triggerTimeoutMillis << endl;
+}
+
+bool Motion::isMotion() {
+  return this->motionDetected;
+}

--- a/nodes/Node_v13/Motion.h
+++ b/nodes/Node_v13/Motion.h
@@ -1,0 +1,27 @@
+#ifndef Motion_h
+#define Motion_h
+
+#include <Arduino.h>
+
+#include <Streaming.h>
+#include <Metro.h>
+
+// https://www.wemos.cc/en/latest/d1_mini_shield/pir.html
+#define PIN_PIR    D2
+
+class Motion {
+  public:
+    void begin();
+    bool update(); // call for update; returns true when motion detected/lost
+
+    void setTriggerTimeout(unsigned long ms); // set length of time to stay triggered
+    bool isMotion();
+    
+  private:
+    Metro triggerTimeout;
+    unsigned long triggerTimeoutMillis = 600000UL;
+    bool motionDetected = false;
+};
+
+
+#endif

--- a/nodes/Node_v13/Node_v13.ino
+++ b/nodes/Node_v13/Node_v13.ino
@@ -32,6 +32,7 @@
 #include <Streaming.h>
 #include <painlessMesh.h>
 #include "Light.h"
+#include "Motion.h"
 
 // some gpio pin that is connected to an LED...
 // on my rig, this is 5, change to the right number of your LED.
@@ -72,6 +73,7 @@ StaticJsonDocument<4096> buffer;
 
 // devices
 Light light;
+Motion motion;
 
 void sendDelayTest() ; // Prototype
 void publishStatus() ; // Prototype
@@ -99,6 +101,7 @@ void setup() {
   pinMode(LED, OUTPUT);
 
   light.begin();
+  motion.begin();
 
   mesh.setDebugMsgTypes(ERROR | DEBUG);  // set before init() so that you can see error messages
 
@@ -155,8 +158,7 @@ void setup() {
   JsonArray skills = status["config"].createNestedArray("skills"); // capabilities
   skills.add("light");
   skills.add("sound");
-  // lack this
-  // hardware.add("motion");
+  skills.add("motion");
 
   // set lighting
   buffer.clear();
@@ -178,6 +180,8 @@ void setup() {
 void loop() {
   mesh.update();
   light.update();
+  motion.update();
+
   digitalWrite(LED, !onFlag);
 }
 
@@ -246,6 +250,7 @@ void receivedCallback(uint32_t from, String & msg) {
     }
     light.setPalette( palette );
   }
+  if ( ! buffer["motion"]["timeout"].isNull() ) motion.setTriggerTimeout( buffer["motion"]["timeout"] );
 
 }
 


### PR DESCRIPTION
Adds support for the PIR motion sensor modules.

This PR implements the Motion library into the Node.  When the PIR sensor detects motion, `Motion::isMotion` will return `true`.  After the PIR sensor detects a lack of motion, `Motion::isMotion` will continue to return `true` for `Motion::triggerTimeoutMillis` milliseconds.